### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Pull Requests
   We actively welcome your pull requests.
   1. Fork the repo and create your branch from `master`. 


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. Even for a project where we don't expect many pull requests or issues, it can help folks see that we are promoting a healthy, safe Open Source Community. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Stack-RNN community profile
checklist](https://github.com/facebook/Stack-RNN/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
![screen shot 2017-12-20 at 10 25 55 am](https://user-images.githubusercontent.com/1114467/34222362-34c02fba-e570-11e7-9ee9-3d842b902185.png)
![screen shot 2017-12-20 at 10 26 02 am](https://user-images.githubusercontent.com/1114467/34222363-34d5bf9c-e570-11e7-935c-1bf71ef5126f.png)

issue:
internal task t23481323